### PR TITLE
Add markdown linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "probot": "^2.0.0",
     "behaviorbot-welcome": "behaviorbot/new-pr-welcome",
-    "probot-settings": "probot/settings"
+    "probot-settings": "probot/settings",
+    "markdownlint": ">= 0.6.1",
+    "node-fetch": ">= 1.7.3"
   },
   "devDependencies": {
     "expect": "^1.20.2",

--- a/src/actions/mdlint.js
+++ b/src/actions/mdlint.js
@@ -1,0 +1,33 @@
+var markdownlint = require("markdownlint");
+var fetch = require("node-fetch");
+
+module.exports = async function(context) {
+  const params = context.issue();
+  const files = context.github.pullRequests.getFiles(params);
+
+  const contents = await Promise.all(
+    files.map(file => {
+      fetch(file.raw_url).then(function(res) {
+        return res.text();
+      }).then(function(text){
+        return [file.filename, text];
+      })
+    })
+  );
+
+  const strings = {};
+
+
+  var options = {
+    strings: contents
+  };
+
+  const lintResult = markdownlint(options, function callback(err, result) {
+    if (!err) {
+      return { body: result.toString() };
+    }
+  });
+
+  // Post a comment on the issue
+  return context.github.issues.createComment(params(lintResult));
+};

--- a/src/actions/mdlint.js
+++ b/src/actions/mdlint.js
@@ -17,6 +17,9 @@ module.exports = async function(context) {
 
   const strings = {};
 
+  contents.forEach(function(pair){
+    strings[pair[0]] = pair[1];
+  });
 
   var options = {
     strings: contents

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,16 @@ encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
+entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
 errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -1705,7 +1715,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.19:
+iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -1931,7 +1941,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2420,6 +2430,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2551,6 +2567,26 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+markdown-it@~8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.3.2.tgz#df4b86530d17c3bc9beec3b68d770b92ea17ae96"
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.3"
+
+"markdownlint@>= 0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.6.1.tgz#61383e2544f7819f6d4717514e57d5f62fd15818"
+  dependencies:
+    markdown-it "~8.3.2"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -2690,6 +2726,13 @@ negotiator@0.6.1:
 netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+
+"node-fetch@>= 1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3844,6 +3887,10 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+uc.micro@^1.0.1, uc.micro@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
This PR adds markdown linting via https://www.npmjs.com/package/markdownlint.

I am using fetch to grab all of the files from a PR, turn their contents into an object of strings, and toss it to markdownlint. The `await Promise.all` here is a bit fun, but shouldn't be a problem given the fact it's a bot - if students follow our one module per PR rule, it should be fine ;).

This PR also incorporates the addition of the Settings probot plugin. We currently use this on the repo already, so we may as well roll it into Prefect. 